### PR TITLE
Secure Issue 36551: Create mobileAppStudy distribution build without …

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -1,0 +1,40 @@
+import org.labkey.gradle.task.ModuleDistribution
+import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.GroupNames
+
+apply plugin: 'org.labkey.distribution'
+
+buildscript {
+    repositories {
+        maven {
+            url "${artifactory_contextUrl}/plugins-release"
+        }
+    }
+    dependencies {
+        classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
+    }
+}
+
+BuildUtils.addModuleDistributionDependencies(project, [":server:internal",
+                                                       ":server:api",
+                                                       ":server:modules:announcements",
+                                                       ":server:modules:audit",
+                                                       ":server:modules:core",
+                                                       ":server:modules:experiment",
+                                                       ":server:modules:filecontent",
+                                                       ":server:modules:pipeline",
+                                                       ":server:modules:query",
+                                                       ":server:modules:wiki",
+                                                       ":server:optionalModules:mobileAppStudy",
+                                                       ":server:modules:list"])
+
+project.task(
+        "distribution",
+        group: GroupNames.DISTRIBUTION,
+        type: ModuleDistribution,
+        {ModuleDistribution dist ->
+            dist.subDirName='mobileAppStudy'
+            dist.includeTarGZArchive=true
+            dist.extraFileIdentifier='-mobileAppStudy'
+        }
+)


### PR DESCRIPTION
…compliance module

Contains a few suggestions from both Trey and Susan for the build.gradle file. Tested locally just now on release18.3-SNAPSHOT with no other downloaded modules besides mobileAppStudy. App builds, starts, and seems to run the demo study just fine. Nothing else should be required from endusers to build, not even an Artifactory login.