### PR TITLE
Data-sharing permission - collect, validate, persist, display

### DIFF
--- a/resources/schemas/dbscripts/postgresql/mobileappstudy-20.000-20.001.sql
+++ b/resources/schemas/dbscripts/postgresql/mobileappstudy-20.000-20.001.sql
@@ -1,0 +1,4 @@
+-- Add new column and populate existing rows with INVALID
+ALTER TABLE mobileappstudy.Participant ADD COLUMN AllowDataSharing VARCHAR(20) NOT NULL DEFAULT 'INVALID';
+-- No longer need that default constraint; insert must supply this value
+ALTER TABLE mobileappstudy.Participant ALTER COLUMN AllowDataSharing DROP DEFAULT;

--- a/resources/schemas/mobileappstudy.xml
+++ b/resources/schemas/mobileappstudy.xml
@@ -59,6 +59,7 @@
         </ns:columns>
     </ns:table>
     <ns:table tableName="Participant" tableDbType="TABLE">
+        <ns:titleColumn>RowId</ns:titleColumn>
         <ns:columns>
             <ns:column columnName="RowId" >
                 <ns:columnTitle>Participant Id</ns:columnTitle>
@@ -78,6 +79,7 @@
                     <ns:fkColumnName>rowId</ns:fkColumnName>
                 </ns:fk>
             </ns:column>
+            <ns:column columnName="AllowDataSharing"/>
             <ns:column columnName="Created"/>
             <ns:column columnName="Container"/>
         </ns:columns>

--- a/resources/schemas/mobileappstudy.xml
+++ b/resources/schemas/mobileappstudy.xml
@@ -157,7 +157,13 @@
             <ns:column columnName="RowId"/>
             <ns:column columnName="ListId"/>
             <ns:column columnName="PropertyURI"/>
-            <ns:column columnName="PropertyType"/>
+            <ns:column columnName="PropertyType">
+                <ns:fk>
+                    <ns:fkDbSchema>mobileappstudy</ns:fkDbSchema>
+                    <ns:fkTable>ParticipantPropertyType</ns:fkTable>
+                    <ns:fkColumnName>rowId</ns:fkColumnName>
+                </ns:fk>
+            </ns:column>
             <ns:column columnName="Created"/>
             <ns:column columnName="Modified"/>
             <ns:column columnName="Container"/>

--- a/src/org/labkey/mobileappstudy/MobileAppStudyManager.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudyManager.java
@@ -227,9 +227,10 @@ public class MobileAppStudyManager
      * enrollment tokens table to link the token to the participant.
      * @param shortName identifier for the study
      * @param tokenValue the token string being used for enrollment
+     * @param allowDataSharing data-sharing permission ("true", "false", or "NA")
      * @return an object representing the participant that was created
      */
-    public Participant enrollParticipant(@NotNull String shortName, @Nullable String tokenValue)
+    public Participant enrollParticipant(@NotNull String shortName, @Nullable String tokenValue, @NotNull String allowDataSharing)
     {
         DbScope scope = MobileAppStudySchema.getInstance().getSchema().getScope();
 
@@ -242,7 +243,7 @@ public class MobileAppStudyManager
             if (tokenValue != null)
             {
                 Optional<MobileAppStudy> studyOpt = studies.stream().filter(s -> getEnrollmentToken(s.getContainer(), tokenValue) != null).findFirst();
-                if (!studyOpt.isPresent())
+                if (studyOpt.isEmpty())
                     throw new RuntimeValidationException("Invalid token '" + tokenValue + "' for study id '" + shortName + "'. Participant cannot be enrolled.");
                 else
                     study = studyOpt.get();
@@ -257,6 +258,7 @@ public class MobileAppStudyManager
             participant.setAppToken(GUID.makeHash());
             participant.setContainer(study.getContainer());
             participant.setStatus(ParticipantStatus.Enrolled);
+            participant.setAllowDataSharing(allowDataSharing);
             participant = Table.insert(null, schema.getTableInfoParticipant(), participant);
             if (tokenValue != null)
             {

--- a/src/org/labkey/mobileappstudy/MobileAppStudyModule.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudyModule.java
@@ -58,7 +58,7 @@ public class MobileAppStudyModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.000;
+        return 20.001;
     }
 
     @Override

--- a/src/org/labkey/mobileappstudy/MobileAppStudySchema.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudySchema.java
@@ -34,7 +34,7 @@ public class MobileAppStudySchema
     public static final String RESPONSE_METADATA_TABLE = "ResponseMetadata";
     public static final String RESPONSE_STATUS_TABLE = "ResponseStatus";
     public static final String PARTICIPANT_PROPERTY_METADATA_TABLE = "ParticipantPropertyMetadata";
-    public static final String PARTICIPANT_PROPERTIES_TYPE_TABLE = "ParticipantPropertiesType";
+    public static final String PARTICIPANT_PROPERTY_TYPE_TABLE = "ParticipantPropertyType";
 
     public static MobileAppStudySchema getInstance()
     {

--- a/src/org/labkey/mobileappstudy/data/Participant.java
+++ b/src/org/labkey/mobileappstudy/data/Participant.java
@@ -52,6 +52,7 @@ public class Participant
     private Container _container;
     private Date _created;
     private ParticipantStatus _status;
+    private String _allowDataSharing;
 
     public String getAppToken()
     {
@@ -107,8 +108,19 @@ public class Participant
     {
         return _status;
     }
+
     public void setStatus(ParticipantStatus status)
     {
         _status = status;
+    }
+
+    public String getAllowDataSharing()
+    {
+        return _allowDataSharing;
+    }
+
+    public void setAllowDataSharing(String allowDataSharing)
+    {
+        _allowDataSharing = allowDataSharing;
     }
 }

--- a/src/org/labkey/mobileappstudy/query/EnrollmentTokenTable.java
+++ b/src/org/labkey/mobileappstudy/query/EnrollmentTokenTable.java
@@ -16,9 +16,9 @@
 package org.labkey.mobileappstudy.query;
 
 import org.labkey.api.data.BaseColumnInfo;
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.SimpleUserSchema;
@@ -33,8 +33,18 @@ import java.util.Collections;
 /**
  * Created by susanh on 10/11/16.
  */
+
 class EnrollmentTokenTable extends SimpleUserSchema.SimpleTable<MobileAppStudyQuerySchema>
 {
+    static final DisplayColumnFactory TOKEN_DISPLAY_COLUMN_FACTORY = colInfo -> new DataColumn(colInfo)
+    {
+        @Override
+        public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
+        {
+            out.write("<span style='font-family: monospace'>" + getFormattedValue(ctx) + "</span>");
+        }
+    };
+
     EnrollmentTokenTable(MobileAppStudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, schema.getDbSchema().getTable(MobileAppStudySchema.ENROLLMENT_TOKEN_TABLE), cf);
@@ -53,18 +63,7 @@ class EnrollmentTokenTable extends SimpleUserSchema.SimpleTable<MobileAppStudyQu
         getMutableColumn("Token").setURL(null);
 
         BaseColumnInfo tokenColumn = getMutableColumn("Token");
-        tokenColumn.setDisplayColumnFactory(colInfo -> new DataColumn(colInfo)
-        {
-            @Override
-            public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
-            {
-                if (null != getValue(ctx))
-                {
-                    out.write("<span style='font-family: monospace'>" + getValue(ctx) + "</span>");
-                }
-
-            }
-        });
+        tokenColumn.setDisplayColumnFactory(TOKEN_DISPLAY_COLUMN_FACTORY);
 
         getMutableColumn("ParticipantId").setURL(null);
     }

--- a/src/org/labkey/mobileappstudy/query/MobileAppStudyQuerySchema.java
+++ b/src/org/labkey/mobileappstudy/query/MobileAppStudyQuerySchema.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.mobileappstudy.query;
 
+import com.google.common.collect.Sets;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
@@ -32,10 +33,13 @@ import org.labkey.mobileappstudy.data.Participant;
 import org.labkey.mobileappstudy.data.SurveyResponse;
 import org.labkey.mobileappstudy.participantproperties.ParticipantProperty;
 
+import java.util.Set;
+
 import static org.labkey.mobileappstudy.MobileAppStudySchema.ENROLLMENT_TOKEN_BATCH_TABLE;
 import static org.labkey.mobileappstudy.MobileAppStudySchema.ENROLLMENT_TOKEN_TABLE;
-import static org.labkey.mobileappstudy.MobileAppStudySchema.PARTICIPANT_PROPERTIES_TYPE_TABLE;
+import static org.labkey.mobileappstudy.MobileAppStudySchema.PARTICIPANT_PROPERTY_TYPE_TABLE;
 import static org.labkey.mobileappstudy.MobileAppStudySchema.PARTICIPANT_STATUS_TABLE;
+import static org.labkey.mobileappstudy.MobileAppStudySchema.PARTICIPANT_TABLE;
 import static org.labkey.mobileappstudy.MobileAppStudySchema.RESPONSE_STATUS_TABLE;
 
 public class MobileAppStudyQuerySchema extends SimpleUserSchema
@@ -60,6 +64,14 @@ public class MobileAppStudyQuerySchema extends SimpleUserSchema
         });
     }
 
+    private static final Set<String> enumTables = Set.of(RESPONSE_STATUS_TABLE, PARTICIPANT_STATUS_TABLE, PARTICIPANT_PROPERTY_TYPE_TABLE);
+
+    @Override
+    public Set<String> getVisibleTableNames()
+    {
+        return Sets.union(super.getVisibleTableNames(), enumTables);
+    }
+
     @Nullable
     @Override
     public TableInfo createTable(String name, ContainerFilter cf)
@@ -72,7 +84,7 @@ public class MobileAppStudyQuerySchema extends SimpleUserSchema
         {
             return new EnrollmentTokenTable(this, cf);
         }
-        else if(RESPONSE_STATUS_TABLE.equalsIgnoreCase(name))
+        else if (RESPONSE_STATUS_TABLE.equalsIgnoreCase(name))
         {
             return new EnumTableInfo<>(
                 SurveyResponse.ResponseStatus.class,
@@ -85,22 +97,26 @@ public class MobileAppStudyQuerySchema extends SimpleUserSchema
         else if (PARTICIPANT_STATUS_TABLE.equalsIgnoreCase(name))
         {
             return new EnumTableInfo<>(
-                    Participant.ParticipantStatus.class,
-                    this,
-                    Participant.ParticipantStatus::getPkId,
-                    true,
-                    "Possible states a Participant might be in"
+                Participant.ParticipantStatus.class,
+                this,
+                Participant.ParticipantStatus::getPkId,
+                true,
+                "Possible states a Participant might be in"
             );
         }
-        else if (PARTICIPANT_PROPERTIES_TYPE_TABLE.equalsIgnoreCase(name))
+        else if (PARTICIPANT_PROPERTY_TYPE_TABLE.equalsIgnoreCase(name))
         {
             return new EnumTableInfo<>(
-                    ParticipantProperty.ParticipantPropertyType.class,
-                    this,
-                    ParticipantProperty.ParticipantPropertyType::getId,
-                    true,
-                    "Possible states a Participant might be in"
+                ParticipantProperty.ParticipantPropertyType.class,
+                this,
+                ParticipantProperty.ParticipantPropertyType::getId,
+                true,
+                "Possible Participant Property types"
             );
+        }
+        else if (PARTICIPANT_TABLE.equalsIgnoreCase(name))
+        {
+            return new ParticipantTable(this, getDbSchema().getTable(PARTICIPANT_TABLE), cf);
         }
         else
             return super.createTable(name, cf);

--- a/src/org/labkey/mobileappstudy/query/MobileAppStudyQuerySchema.java
+++ b/src/org/labkey/mobileappstudy/query/MobileAppStudyQuerySchema.java
@@ -119,6 +119,16 @@ public class MobileAppStudyQuerySchema extends SimpleUserSchema
             return new ParticipantTable(this, getDbSchema().getTable(PARTICIPANT_TABLE), cf);
         }
         else
-            return super.createTable(name, cf);
+        {
+            TableInfo ti = super.createTable(name, cf);
+
+            if (ti instanceof SimpleTable)
+            {
+                //noinspection unchecked
+                ((SimpleTable<MobileAppStudyQuerySchema>) ti).setReadOnly(true);
+            }
+
+            return ti;
+        }
     }
 }

--- a/src/org/labkey/mobileappstudy/query/ParticipantTable.java
+++ b/src/org/labkey/mobileappstudy/query/ParticipantTable.java
@@ -1,12 +1,11 @@
 package org.labkey.mobileappstudy.query;
 
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SchemaTableInfo;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.query.AliasedColumn;
-import org.labkey.api.query.LookupForeignKey;
+import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.SimpleUserSchema.SimpleTable;
 
 import static org.labkey.mobileappstudy.MobileAppStudySchema.ENROLLMENT_TOKEN_TABLE;
@@ -22,18 +21,15 @@ public class ParticipantTable extends SimpleTable<MobileAppStudyQuerySchema>
         wrapAllColumns();
 
         // graft the enrollment token into this table for convenience - can be added to every response list, if desired
-        BaseColumnInfo token = new AliasedColumn(this, "Token", dbTable.getColumn("RowId"));
-        token.setFk(new LookupForeignKey("ParticipantId", "Token")
-        {
-            @Override
-            public @Nullable TableInfo getLookupTableInfo()
-            {
-                return schema.getTable(ENROLLMENT_TOKEN_TABLE, cf);
-            }
-        });
+        SQLFragment sql = new SQLFragment("(SELECT Token FROM mobileappstudy.")
+            .append(ENROLLMENT_TOKEN_TABLE)
+            .append(" tt WHERE tt.ParticipantId=")
+            .append(ExprColumn.STR_TABLE_ALIAS)
+            .append(".RowId)");
+        BaseColumnInfo token = new ExprColumn(this, "Token", sql, JdbcType.VARCHAR, getColumn("RowId"));
         token.setDisplayColumnFactory(TOKEN_DISPLAY_COLUMN_FACTORY);
-
         addColumn(token);
+
         setReadOnly(true);
     }
 }

--- a/src/org/labkey/mobileappstudy/query/ParticipantTable.java
+++ b/src/org/labkey/mobileappstudy/query/ParticipantTable.java
@@ -1,0 +1,39 @@
+package org.labkey.mobileappstudy.query;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.BaseColumnInfo;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.SchemaTableInfo;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.AliasedColumn;
+import org.labkey.api.query.LookupForeignKey;
+import org.labkey.api.query.SimpleUserSchema.SimpleTable;
+
+import static org.labkey.mobileappstudy.MobileAppStudySchema.ENROLLMENT_TOKEN_TABLE;
+import static org.labkey.mobileappstudy.query.EnrollmentTokenTable.TOKEN_DISPLAY_COLUMN_FACTORY;
+
+public class ParticipantTable extends SimpleTable<MobileAppStudyQuerySchema>
+{
+    ParticipantTable(MobileAppStudyQuerySchema schema, SchemaTableInfo dbTable, ContainerFilter cf)
+    {
+        super(schema, dbTable, cf);
+
+        // wrap all the existing columns
+        wrapAllColumns();
+
+        // graft the enrollment token into this table for convenience - can be added to every response list, if desired
+        BaseColumnInfo token = new AliasedColumn(this, "Token", dbTable.getColumn("RowId"));
+        token.setFk(new LookupForeignKey("ParticipantId", "Token")
+        {
+            @Override
+            public @Nullable TableInfo getLookupTableInfo()
+            {
+                return schema.getTable(ENROLLMENT_TOKEN_TABLE, cf);
+            }
+        });
+        token.setDisplayColumnFactory(TOKEN_DISPLAY_COLUMN_FACTORY);
+
+        addColumn(token);
+        setReadOnly(true);
+    }
+}

--- a/test/src/org/labkey/test/commands/mobileappstudy/EnrollParticipantCommand.java
+++ b/test/src/org/labkey/test/commands/mobileappstudy/EnrollParticipantCommand.java
@@ -36,7 +36,7 @@ public class EnrollParticipantCommand extends MobileAppCommand
     private String _studyName;
     private String _appToken;
     private String _projectName;
-    private final String _allowDataSharing;
+    private String _allowDataSharing;
 
     public String getProjectName()
     {
@@ -78,6 +78,11 @@ public class EnrollParticipantCommand extends MobileAppCommand
     public String getAllowDataSharing()
     {
         return _allowDataSharing;
+    }
+
+    public void setAllowDataSharing(String allowDataSharing)
+    {
+        _allowDataSharing = allowDataSharing;
     }
 
     @Override

--- a/test/src/org/labkey/test/commands/mobileappstudy/EnrollParticipantCommand.java
+++ b/test/src/org/labkey/test/commands/mobileappstudy/EnrollParticipantCommand.java
@@ -36,6 +36,7 @@ public class EnrollParticipantCommand extends MobileAppCommand
     private String _studyName;
     private String _appToken;
     private String _projectName;
+    private final String _allowDataSharing;
 
     public String getProjectName()
     {
@@ -46,11 +47,12 @@ public class EnrollParticipantCommand extends MobileAppCommand
         _projectName = projectName;
     }
 
-    public EnrollParticipantCommand(String project, String studyName, String batchToken, Consumer<String> logger)
+    public EnrollParticipantCommand(String project, String studyName, String batchToken, String allowDataSharing, Consumer<String> logger)
     {
         _studyName = studyName;
         _batchToken = batchToken;
         _projectName = project;
+        _allowDataSharing = allowDataSharing;
 
         setLogger(logger);
     }
@@ -73,6 +75,11 @@ public class EnrollParticipantCommand extends MobileAppCommand
         _batchToken = batchToken;
     }
 
+    public String getAllowDataSharing()
+    {
+        return _allowDataSharing;
+    }
+
     @Override
     public HttpResponse execute(int expectedStatusCode)
     {
@@ -87,6 +94,7 @@ public class EnrollParticipantCommand extends MobileAppCommand
         params.put("studyId", getStudyName());
         if (StringUtils.isNotBlank(getBatchToken()))
             params.put("token", getBatchToken());
+        params.put("allowDataSharing", getAllowDataSharing());
         return WebTestHelper.buildURL(CONTROLLER_NAME, getProjectName(), ACTION_NAME, params);
     }
 

--- a/test/src/org/labkey/test/commands/mobileappstudy/MobileAppCommand.java
+++ b/test/src/org/labkey/test/commands/mobileappstudy/MobileAppCommand.java
@@ -109,6 +109,7 @@ public abstract class MobileAppCommand
 
     protected HttpResponse execute(HttpUriRequest request, int expectedStatusCode)
     {
+        setExceptionMessage(null); // Clear out previous exception message, in case we're reusing this Command
         HttpResponse response = null;
         log("Submitting request using url: " + request.getURI());
 

--- a/test/src/org/labkey/test/tests/mobileappstudy/BaseMobileAppStudyTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/BaseMobileAppStudyTest.java
@@ -101,7 +101,7 @@ public abstract class BaseMobileAppStudyTest extends BaseWebDriverTest implement
     String getNewAppToken(String project, String studyShortName, String batchToken)
     {
         log("Requesting app token for project [" + project +"] and study [" + studyShortName + "]");
-        EnrollParticipantCommand cmd = new EnrollParticipantCommand(project, studyShortName, batchToken, this::log);
+        EnrollParticipantCommand cmd = new EnrollParticipantCommand(project, studyShortName, batchToken, "true", this::log);
 
         cmd.execute(200);
         String appToken = cmd.getAppToken();

--- a/test/src/org/labkey/test/tests/mobileappstudy/BaseMobileAppStudyTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/BaseMobileAppStudyTest.java
@@ -197,7 +197,7 @@ public abstract class BaseMobileAppStudyTest extends BaseWebDriverTest implement
     protected CommandResponse assignToken(Connection connection, @LoggedParam String token, @LoggedParam String projectName, @LoggedParam String studyName) throws IOException, CommandException
     {
         Command command = new PostCommand("mobileappstudy", "enroll");
-        HashMap<String, Object> params = new HashMap<>(Maps.of("shortName", studyName, "token", token));
+        HashMap<String, Object> params = new HashMap<>(Maps.of("shortName", studyName, "token", token, "allowDataSharing", "true"));
         command.setParameters(params);
         log("Assigning token: " + token);
         return command.execute(connection, projectName);

--- a/test/src/org/labkey/test/tests/mobileappstudy/DynamicSchemaTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/DynamicSchemaTest.java
@@ -16,7 +16,6 @@
 package org.labkey.test.tests.mobileappstudy;
 
 import org.jetbrains.annotations.Nullable;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.categories.Git;
@@ -534,15 +533,8 @@ public class DynamicSchemaTest extends BaseMobileAppStudyTest
 
         // Verify "no other" block parses and gets expected responses and columns
         List<Map<String, Object>> afterTable = getTableData(noOtherOptionTableName);
-        assertEquals("Unexpected number of rows in  for no `other` option.", 2, afterTable.size());
-//        assertEquals("Unexpected number of columns for no `other` option.", 16, afterTable.get(0).keySet().size());
-//
-        // Log the keys to help track down missing column
-        if (afterTable.get(0).keySet().size() != 16)
-        {
-            log(afterTable.get(0).keySet().toString());
-            Assert.fail("Unexpected number of columns for no `other` option: was " + afterTable.get(0).keySet().size() + " but expected 16");
-        }
+        assertEquals("Unexpected number of rows in for no `other` option.", 2, afterTable.size());
+        assertEquals("Unexpected number of columns for no `other` option.", 15, afterTable.get(0).keySet().size());
 
         // Verify other block parses and gets expected responses and columns
         afterTable = getTableData(optionRequiredTableName);

--- a/test/src/org/labkey/test/tests/mobileappstudy/DynamicSchemaTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/DynamicSchemaTest.java
@@ -16,9 +16,9 @@
 package org.labkey.test.tests.mobileappstudy;
 
 import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Git;
 import org.labkey.test.commands.mobileappstudy.SubmitResponseCommand;
 import org.labkey.test.pages.list.BeginPage;
@@ -532,10 +532,17 @@ public class DynamicSchemaTest extends BaseMobileAppStudyTest
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 
-        // Verify no other block parses and gets expected responses and columns
+        // Verify "no other" block parses and gets expected responses and columns
         List<Map<String, Object>> afterTable = getTableData(noOtherOptionTableName);
         assertEquals("Unexpected number of rows in  for no `other` option.", 2, afterTable.size());
-        assertEquals("Unexpected number of columns for no `other` option.", 16, afterTable.get(0).keySet().size());
+//        assertEquals("Unexpected number of columns for no `other` option.", 16, afterTable.get(0).keySet().size());
+//
+        // Log the keys to help track down missing column
+        if (afterTable.get(0).keySet().size() != 16)
+        {
+            log(afterTable.get(0).keySet().toString());
+            Assert.fail("Unexpected number of columns for no `other` option: was " + afterTable.get(0).keySet().size() + " but expected 16");
+        }
 
         // Verify other block parses and gets expected responses and columns
         afterTable = getTableData(optionRequiredTableName);

--- a/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
@@ -223,14 +223,13 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
         enrollCmd.execute(200);
         assertTrue("Enrollment with token '" + token + "' for " + CLIENT_1_TOKEN_STUDY + " failed when it shouldn't have", enrollCmd.getSuccess());
 
-        log("AppToken: " + enrollCmd.getAppToken());
-
         Connection cn = WebTestHelper.getRemoteApiConnection();
         SelectRowsCommand cmd = new SelectRowsCommand("mobileappstudy", "Participant");
-        cmd.setColumns(List.of("allowDataSharing"));
+        cmd.setColumns(List.of("AllowDataSharing", "Token"));
         cmd.addFilter("AppToken", enrollCmd.getAppToken(), Filter.Operator.EQUAL);
         SelectRowsResponse resp = cmd.execute(cn, CLIENT_1_TOKEN_STUDY);
 
+        // TODO: Ensure that AllowDataSharing and Token values show up in the Participant table
         log(resp.getRows().toString());
     }
 

--- a/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
@@ -117,7 +117,7 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
         assertEquals("Study name not saved for second project", SHORT_NAME.toUpperCase(), setupPage.getStudySetupWebPart().getShortName());
 
         log("Testing enrollment, which should fail without any tokens.");
-        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", SHORT_NAME, null, this::log);
+        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", SHORT_NAME, null, "NA", this::log);
         enrollCmd.execute(400);
         assertFalse("Enrollment should fail when two projects share a study id but have no enrollment tokens", enrollCmd.getSuccess());
     }
@@ -150,23 +150,20 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
         TokenListPage tokenListPage = TokenListPage.beginAt(this, CLIENT_1_TOKEN_STUDY);
         String token = tokenListPage.getToken(0);
 
-        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token, this::log);
+        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token, "true", this::log);
         enrollCmd.execute(200);
         assertTrue("Enrollment with token '" + token + "' for " + CLIENT_1_TOKEN_STUDY + " failed when it shouldn't have", enrollCmd.getSuccess());
         EnrollmentTokenValidationCommand validateCmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token, this::log);
         validateCmd.execute(400);
         assertFalse("Enrollment token validation for " + CLIENT_1_TOKEN_STUDY + " with token '" + token + "' should fail after enrollment succeeds", validateCmd.getSuccess());
 
-
         tokenListPage = TokenListPage.beginAt(this, CLIENT_2_TOKEN_STUDY);
         token = tokenListPage.getToken(0);
-        enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token, this::log);
+        enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token, "false", this::log);
         enrollCmd.execute(200);
         assertTrue("Enrollment with token '" + token + "' for  " + CLIENT_2_TOKEN_STUDY + " failed when it shouldn't have", enrollCmd.getSuccess());
         validateCmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token, this::log);
         validateCmd.execute(400);
         assertFalse("Enrollment token validation for " + CLIENT_2_TOKEN_STUDY + " with token '" + token + "' should fail after enrollment succeeds", validateCmd.getSuccess());
-
     }
-
 }

--- a/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
@@ -226,7 +226,7 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
         log("AppToken: " + enrollCmd.getAppToken());
 
         Connection cn = WebTestHelper.getRemoteApiConnection();
-        SelectRowsCommand cmd = new SelectRowsCommand("mobilestudyapp", "Participant");
+        SelectRowsCommand cmd = new SelectRowsCommand("mobileappstudy", "Participant");
         cmd.setColumns(List.of("allowDataSharing"));
         cmd.addFilter("AppToken", enrollCmd.getAppToken(), Filter.Operator.EQUAL);
         SelectRowsResponse resp = cmd.execute(cn, CLIENT_1_TOKEN_STUDY);

--- a/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.pages.mobileappstudy.TokenListPage;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -177,9 +178,9 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
     }
 
     @Test
+    // test validation of the "allowDataSharing" parameter at enrollment time
     public void testAllowDataSharingValidation() throws IOException, CommandException
     {
-        // test validation of the "allowDataSharing" parameter at enrollment time
         TokenListPage tokenListPage = TokenListPage.beginAt(this, CLIENT_1_TOKEN_STUDY);
         String token1 = tokenListPage.getToken(1);
         String token2 = tokenListPage.getToken(2);
@@ -229,8 +230,10 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
         cmd.addFilter("AppToken", enrollCmd.getAppToken(), Filter.Operator.EQUAL);
         SelectRowsResponse resp = cmd.execute(cn, CLIENT_1_TOKEN_STUDY);
 
-        // TODO: Ensure that AllowDataSharing and Token values show up in the Participant table
-        log(resp.getRows().toString());
+        // Ensure that expected AllowDataSharing and Token values show up in the Participant table
+        Map<String, Object> map = resp.getRows().get(0);
+        assertEquals(allowDataSharing, map.get("AllowDataSharing"));
+        assertEquals(token, map.get("Token"));
     }
 
     private void testRequired(EnrollParticipantCommand enrollCmd, String allowDataSharing)

--- a/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
@@ -180,7 +180,7 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
         EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token1, null, this::log);
         testRequired(enrollCmd, null);
         testRequired(enrollCmd, "");
-        testRequired(enrollCmd, "  ");
+        testRequired(enrollCmd, "%20%20%20");
         testInvalid(enrollCmd, "na");
         testInvalid(enrollCmd, "n/a");
         testInvalid(enrollCmd, "N/A");

--- a/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
@@ -170,13 +170,13 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
     @Test
     public void testAllowDataSharingValidation()
     {
-        // test the validation of the "allowDataSharing" parameter at enrollment time
+        // test validation of the "allowDataSharing" parameter at enrollment time
         TokenListPage tokenListPage = TokenListPage.beginAt(this, CLIENT_1_TOKEN_STUDY);
         String token1 = tokenListPage.getToken(1);
         String token2 = tokenListPage.getToken(2);
         String token3 = tokenListPage.getToken(3);
 
-        // test null, blank, and invalid values - should all fail
+        // test null, blank, and invalid values - all should fail
         EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token1, null, this::log);
         testRequired(enrollCmd, null);
         testRequired(enrollCmd, "");
@@ -201,7 +201,7 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
         testInvalid(enrollCmd, "Wombat");
         testInvalid(enrollCmd, "Mazipan");
 
-        // test the three valid values - should all succeed
+        // test the three valid values - all should succeed
         enrollCmd.setAllowDataSharing("true");
         enrollCmd.execute(200);
         assertTrue("Enrollment with token '" + token1 + "' for " + CLIENT_1_TOKEN_STUDY + " failed when it shouldn't have", enrollCmd.getSuccess());


### PR DESCRIPTION
#### Rationale
FDA MyStudies provides the option to ask participants if they consent to their data being shared with 3rd parties for research. This change to the Response server collects, validates, persists, and makes this flag available in grids and downstream analysis. https://docs.google.com/document/d/15_G_Po8e4tMuDyxKE5r1Ocw7t1Hmdfw95KOcgd3Jucc/edit#

#### Changes
* Collect, validate, and persist a new, required "allowDataSharing" parameter at enrollment time (enroll.api). Valid values are "true", 'false", "NA".
* Make AllowDataSharing column available in response grids, export, APIs, queries, etc.
* Fix existing automated tests and add an explicit test of "allowDataSharing" valid & invalid values.
* Graft "Token" column into Participant table for easy joining of the enrollment token into response lists.
* Expose enum tables to the user schema so they show up in schema browser, etc.