### PR TITLE
Change optionalModules to modules as checkout location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ This module must be deployed within the LabKey Server platform (version 19.2.x).
 1. In your settings.gradle file, find the commented out line with this text:
 
     ```
-    //include ":server:optionalModules:workflow"
+    //include ":server:modules:workflow"
     ```
 
 1. Underneath this line, add these two lines:
 
    ```
-   include ":server:optionalModules:mobileAppStudy"
-   include ":server:optionalModules:mobileAppStudy:distributions:fda"
+   include ":server:modules:mobileAppStudy"
+   include ":server:modules:mobileAppStudy:distributions:fda"
    ```
 
 1. On the command line (again, in the root of your working copy), run one of these commands (use the first command on Linux/OSX and the second on Windows):
 
     ```
-    ./gradlew :server:optionalModules:mobileAppStudy:distributions:fda:dist
-    gradlew :server:optionalModules:mobileAppStudy:distributions:fda:dist
+    ./gradlew :server:modules:mobileAppStudy:distributions:fda:dist
+    gradlew :server:modules:mobileAppStudy:distributions:fda:dist
     ```
 
 1. Look in the directory "dist/mobileAppStudy" for a file whose name ends with "mobileAppStudy-bin.tar.gz". Install this distribution using the [Install LabKey Manually](https://www.labkey.org/Documentation/wiki-page.view?name=manualInstall) instructions.

--- a/distributions/fda/build.gradle
+++ b/distributions/fda/build.gradle
@@ -23,7 +23,7 @@ BuildUtils.addModuleDistributionDependencies(project, [BuildUtils.getApiProjectP
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "filecontent"),
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"),
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"),
-                                                       ":server:optionalModules:mobileAppStudy",
+                                                       ":server:modules:mobileAppStudy",
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "list")])
 
 project.task(

--- a/test/src/org/labkey/test/tests/mobileappstudy/BaseMobileAppStudyTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/BaseMobileAppStudyTest.java
@@ -247,7 +247,7 @@ public abstract class BaseMobileAppStudyTest extends BaseWebDriverTest implement
 
     protected void setSurveyMetadataDropDir()
     {
-        ModulePropertyValue val = new ModulePropertyValue("MobileAppStudy", "/", "SurveyMetadataDirectory", TestFileUtils.getLabKeyRoot() + "/server/optionalModules/mobileAppStudy/test/sampledata/SurveyMetadata/");
+        ModulePropertyValue val = new ModulePropertyValue("MobileAppStudy", "/", "SurveyMetadataDirectory", TestFileUtils.getLabKeyRoot() + "/server/modules/mobileAppStudy/test/sampledata/SurveyMetadata/");
         setModuleProperties(Arrays.asList(val));
     }
 

--- a/test/src/org/labkey/test/tests/mobileappstudy/BaseMobileAppStudyTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/BaseMobileAppStudyTest.java
@@ -247,7 +247,7 @@ public abstract class BaseMobileAppStudyTest extends BaseWebDriverTest implement
 
     protected void setSurveyMetadataDropDir()
     {
-        ModulePropertyValue val = new ModulePropertyValue("MobileAppStudy", "/", "SurveyMetadataDirectory", TestFileUtils.getLabKeyRoot() + "/server/modules/mobileAppStudy/test/sampledata/SurveyMetadata/");
+        ModulePropertyValue val = new ModulePropertyValue("MobileAppStudy", "/", "SurveyMetadataDirectory", TestFileUtils.getSampleData("SurveyMetadata").getAbsolutePath());
         setModuleProperties(Arrays.asList(val));
     }
 


### PR DESCRIPTION
#### Rationale
Consolidate to server/modules as the preferred location for building module code 

#### Related Pull Requests
https://github.com/LabKey/trialServices/pull/17
https://github.com/LabKey/tnprc_billing/pull/55
https://github.com/LabKey/tnprc_ehr/pull/236
https://github.com/LabKey/premium/pull/187
https://github.com/LabKey/medImmuneFlow/pull/16
https://github.com/LabKey/MaxQuant/pull/24
https://github.com/LabKey/provenance/pull/21
https://github.com/LabKey/cds/pull/269
https://github.com/LabKey/evaluationContent/pull/29
https://github.com/LabKey/PanoramaPremiumModules/pull/29
https://github.com/LabKey/redcap/pull/24
https://github.com/LabKey/scrumtime/pull/57
https://github.com/LabKey/medImmune/pull/66
https://github.com/LabKey/gel/pull/195

TBD

#### Changes
Update README, build.gradle