### PR TITLE
appendNavTrail() to addNavTrail() migration

### DIFF
--- a/src/org/labkey/mobileappstudy/MobileAppStudyController.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudyController.java
@@ -143,9 +143,8 @@ public class MobileAppStudyController extends SpringActionController
     public class TokenBatchAction extends SimpleViewAction
     {
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
 
         @Override
@@ -160,11 +159,10 @@ public class MobileAppStudyController extends SpringActionController
     public class TokenListAction extends SimpleViewAction
     {
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Token Batches", getEnrollmentTokenBatchURL());
             root.addChild("Enrollment Tokens");
-            return root;
         }
 
         @Override

--- a/src/org/labkey/mobileappstudy/query/ReadResponsesQuerySchema.java
+++ b/src/org/labkey/mobileappstudy/query/ReadResponsesQuerySchema.java
@@ -78,6 +78,7 @@ public class ReadResponsesQuerySchema extends UserSchema
                 return true;
             }
 
+            @Override
             public QuerySchema createSchema(DefaultSchema schema, Module module)
             {
                 return new ReadResponsesQuerySchema(schema.getUser(), schema.getContainer(), null);

--- a/src/org/labkey/mobileappstudy/surveydesign/SurveyStep.java
+++ b/src/org/labkey/mobileappstudy/surveydesign/SurveyStep.java
@@ -391,6 +391,7 @@ public class SurveyStep implements IDynamicListField
         return SurveyStepType.getStepType(type);
     }
 
+    @Override
     public String getKey()
     {
         return key;
@@ -446,6 +447,7 @@ public class SurveyStep implements IDynamicListField
         return null;
     }
 
+    @Override
     @JsonIgnore
     @Nullable
     public Integer getMaxLength()
@@ -481,6 +483,7 @@ public class SurveyStep implements IDynamicListField
         return Style.getStyle(val);
     }
 
+    @Override
     @JsonIgnore
     public JdbcType getPropertyStorageType()
     {

--- a/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
+++ b/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
@@ -52,6 +52,7 @@ public class EnrollmentTokenBatchesWebPart extends QueryView
         return schema.getSettings(viewContext, "enrollmentTokenBatches", MobileAppStudySchema.ENROLLMENT_TOKEN_BATCH_TABLE);
     }
 
+    @Override
     protected void populateButtonBar(DataView view, ButtonBar bar)
     {
         super.populateButtonBar(view, bar);

--- a/test/src/org/labkey/test/commands/mobileappstudy/SubmitResponseCommand.java
+++ b/test/src/org/labkey/test/commands/mobileappstudy/SubmitResponseCommand.java
@@ -130,6 +130,7 @@ public class SubmitResponseCommand extends MobileAppCommand
         this.body = body;
     }
 
+    @Override
     public String getBody()
     {
         return this.body;

--- a/test/src/org/labkey/test/components/mobileappstudy/ForwardingTab.java
+++ b/test/src/org/labkey/test/components/mobileappstudy/ForwardingTab.java
@@ -32,6 +32,7 @@ public class ForwardingTab extends LabKeyPage<ForwardingTab.ElementCache> implem
         return new ForwardingTab(driver);
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/test/src/org/labkey/test/components/mobileappstudy/TokenBatchesWebPart.java
+++ b/test/src/org/labkey/test/components/mobileappstudy/TokenBatchesWebPart.java
@@ -64,6 +64,7 @@ public class TokenBatchesWebPart extends BodyWebPart<TokenBatchesWebPart.Element
         return elementCache().tokenBatchDataRegion.getRowDataAsMap("RowId", batchId);
     }
 
+    @Override
     protected void waitForReady()
     {
         elementCache().tokenBatchDataRegion.getComponentElement().isDisplayed();

--- a/test/src/org/labkey/test/data/mobileappstudy/AbstractQuestionResponse.java
+++ b/test/src/org/labkey/test/data/mobileappstudy/AbstractQuestionResponse.java
@@ -134,7 +134,9 @@ public abstract class AbstractQuestionResponse implements QuestionResult
         _omitType = omitType;
     }
 
+    @Override
     public abstract String getJsonString();
+    @Override
     public abstract Object getResult();
     public void setOmitResult(boolean flag)
     {

--- a/test/src/org/labkey/test/data/mobileappstudy/FormQuestionResponse.java
+++ b/test/src/org/labkey/test/data/mobileappstudy/FormQuestionResponse.java
@@ -35,6 +35,7 @@ public class FormQuestionResponse extends Form implements QuestionResult
         );
     }
 
+    @Override
     public Object getResult()
     {
         return responses;

--- a/test/src/org/labkey/test/data/mobileappstudy/QuestionResponse.java
+++ b/test/src/org/labkey/test/data/mobileappstudy/QuestionResponse.java
@@ -26,6 +26,7 @@ public class QuestionResponse extends AbstractQuestionResponse
 {
     private Object _result;
 
+    @Override
     public Object getResult()
     {
         return _result;
@@ -50,6 +51,7 @@ public class QuestionResponse extends AbstractQuestionResponse
         setResult(result);
     }
 
+    @Override
     public String getJsonString()
     {
         return String.format(getQuestionResponseJsonFormat(), getType().getDisplayText(), getQuestionId(), DATE_FORMAT.format(getStart()),

--- a/test/src/org/labkey/test/tests/mobileappstudy/DynamicSchemaTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/DynamicSchemaTest.java
@@ -50,6 +50,7 @@ public class DynamicSchemaTest extends BaseMobileAppStudyTest
     private static List<Map<String,Object>> newSurveyGroupedTextChoiceField;
     private static List<Map<String,Object>> newSurveyTextChoiceField;
 
+    @Override
     protected
     @Nullable String getProjectName()
     {


### PR DESCRIPTION
#### Rationale
Adjust actions to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. Also, bulk annotate with @Override. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199