### PR TITLE
ResolveEnrollmentToken API

### DIFF
--- a/src/org/labkey/mobileappstudy/MobileAppStudyController.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudyController.java
@@ -423,9 +423,14 @@ public class MobileAppStudyController extends SpringActionController
             response.put("success", success);
 
             if (success)
+            {
                 response.put("studyId", studyId);
+            }
             else
+            {
                 response.put("message", "Token is not associated with a study ID");
+                getViewContext().getResponse().setStatus(404);
+            }
 
             return response;
         }

--- a/test/src/org/labkey/test/commands/mobileappstudy/EnrollmentTokenValidationCommand.java
+++ b/test/src/org/labkey/test/commands/mobileappstudy/EnrollmentTokenValidationCommand.java
@@ -127,7 +127,7 @@ public class EnrollmentTokenValidationCommand extends MobileAppCommand
         }
         catch (IOException e)
         {
-            //TODO: do something here...
+            throw new RuntimeException(e);
         }
     }
 }

--- a/test/src/org/labkey/test/commands/mobileappstudy/ResolveEnrollmentTokenCommand.java
+++ b/test/src/org/labkey/test/commands/mobileappstudy/ResolveEnrollmentTokenCommand.java
@@ -21,40 +21,22 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.json.simple.JSONObject;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.data.mobileappstudy.ParticipantPropertiesResponse;
-import org.labkey.test.data.mobileappstudy.ParticipantProperty;
+import org.labkey.test.data.mobileappstudy.ResolveEnrollmentTokenResponse;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
 
-public class EnrollmentTokenValidationCommand extends MobileAppCommand
+public class ResolveEnrollmentTokenCommand extends MobileAppCommand
 {
     protected static final String CONTROLLER_NAME = "mobileappstudy";
-    protected static final String ACTION_NAME = "validateenrollmenttoken";
-    public static final String INVALID_STUDYID_FORMAT = "Study with StudyId '%1$s' does not exist";
-    public static final String INVALID_TOKEN_FORMAT = "Invalid token: '%1$s'";
-    public static final String BLANK_STUDYID = "StudyId is required";
-    public static final String TOKEN_REQUIRED = "Token is required";
+    protected static final String ACTION_NAME = "resolveenrollmenttoken";
 
     private String _batchToken;
-    private String _studyName;
     private String _projectName;
-
-    private Collection<ParticipantProperty> _preEnrollmentParticipantProperties;
-
-    public void setPreEnrollmentParticipantProperties(Collection<ParticipantProperty> preEnrollmentParticipantProperties)
-    {
-        _preEnrollmentParticipantProperties = preEnrollmentParticipantProperties;
-    }
-
-    public Collection<ParticipantProperty> getPreEnrollmentParticipantProperties()
-    {
-        return _preEnrollmentParticipantProperties;
-    }
+    private String _studyId;
 
     public String getProjectName()
     {
@@ -65,22 +47,12 @@ public class EnrollmentTokenValidationCommand extends MobileAppCommand
         _projectName = projectName;
     }
 
-    public EnrollmentTokenValidationCommand(String project, String studyName, String batchToken, Consumer<String> logger)
+    public ResolveEnrollmentTokenCommand(String project, String batchToken, Consumer<String> logger)
     {
-        _studyName = studyName;
         _batchToken = batchToken;
         _projectName = project;
 
         setLogger(logger);
-    }
-
-    public String getStudyName()
-    {
-        return _studyName;
-    }
-    public void setStudyName(String studyName)
-    {
-        _studyName = studyName;
     }
 
     public String getBatchToken()
@@ -90,6 +62,11 @@ public class EnrollmentTokenValidationCommand extends MobileAppCommand
     public void setBatchToken(String batchToken)
     {
         _batchToken = batchToken;
+    }
+
+    public String getStudyId()
+    {
+        return _studyId;
     }
 
     @Override
@@ -103,7 +80,6 @@ public class EnrollmentTokenValidationCommand extends MobileAppCommand
     public String getTargetURL()
     {
         Map<String, String> params = new HashMap<>();
-        params.put("studyId", getStudyName());
         if (StringUtils.isNotBlank(getBatchToken()))
             params.put("token", getBatchToken());
         return WebTestHelper.buildURL(CONTROLLER_NAME, getProjectName(), ACTION_NAME, params);
@@ -121,9 +97,9 @@ public class EnrollmentTokenValidationCommand extends MobileAppCommand
         ObjectMapper mapper = new ObjectMapper();
         try
         {
-            ParticipantPropertiesResponse ppResponse = mapper.readValue(response.toJSONString(), ParticipantPropertiesResponse.class);
-            if (ppResponse != null)
-                _preEnrollmentParticipantProperties = ppResponse.getPreEnrollmentParticipantProperties();
+            ResolveEnrollmentTokenResponse enrollmentTokenResponse = mapper.readValue(response.toJSONString(), ResolveEnrollmentTokenResponse.class);
+            if (null != enrollmentTokenResponse)
+                _studyId = enrollmentTokenResponse.getStudyId();
         }
         catch (IOException e)
         {

--- a/test/src/org/labkey/test/commands/mobileappstudy/ResolveEnrollmentTokenCommand.java
+++ b/test/src/org/labkey/test/commands/mobileappstudy/ResolveEnrollmentTokenCommand.java
@@ -36,7 +36,9 @@ public class ResolveEnrollmentTokenCommand extends MobileAppCommand
 
     private String _batchToken;
     private String _projectName;
+
     private String _studyId;
+    private String _message;
 
     public String getProjectName()
     {
@@ -69,6 +71,11 @@ public class ResolveEnrollmentTokenCommand extends MobileAppCommand
         return _studyId;
     }
 
+    public String getMessage()
+    {
+        return _message;
+    }
+
     @Override
     public HttpResponse execute(int expectedStatusCode)
     {
@@ -89,6 +96,13 @@ public class ResolveEnrollmentTokenCommand extends MobileAppCommand
     public String getBody()
     {
         return "";
+    }
+
+    @Override
+    protected void parseErrorResponse(JSONObject response)
+    {
+        super.parseErrorResponse(response);
+        _message = (String)response.get("message");
     }
 
     @Override

--- a/test/src/org/labkey/test/commands/mobileappstudy/ResolveEnrollmentTokenCommand.java
+++ b/test/src/org/labkey/test/commands/mobileappstudy/ResolveEnrollmentTokenCommand.java
@@ -117,7 +117,7 @@ public class ResolveEnrollmentTokenCommand extends MobileAppCommand
         }
         catch (IOException e)
         {
-            //TODO: do something here...
+            throw new RuntimeException(e);
         }
     }
 }

--- a/test/src/org/labkey/test/data/mobileappstudy/ParticipantPropertiesResponse.java
+++ b/test/src/org/labkey/test/data/mobileappstudy/ParticipantPropertiesResponse.java
@@ -9,14 +9,14 @@ public class ParticipantPropertiesResponse
 {
     private Collection<ParticipantProperty> _preEnrollmentParticipantProperties;
 
-
-    public void setPreEnrollmentParticipantProperties(Collection<ParticipantProperty> _participantProperties)
+    @SuppressWarnings("unused")
+    public void setPreEnrollmentParticipantProperties(Collection<ParticipantProperty> participantProperties)
     {
-        this._preEnrollmentParticipantProperties = _participantProperties;
+        _preEnrollmentParticipantProperties = participantProperties;
     }
 
     public Collection<ParticipantProperty> getPreEnrollmentParticipantProperties()
     {
-        return this._preEnrollmentParticipantProperties;
+        return _preEnrollmentParticipantProperties;
     }
 }

--- a/test/src/org/labkey/test/data/mobileappstudy/ResolveEnrollmentTokenResponse.java
+++ b/test/src/org/labkey/test/data/mobileappstudy/ResolveEnrollmentTokenResponse.java
@@ -1,0 +1,20 @@
+package org.labkey.test.data.mobileappstudy;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResolveEnrollmentTokenResponse
+{
+    private String _studyId;
+
+    @SuppressWarnings("unused")
+    public void setStudyId(String studyId)
+    {
+        _studyId = studyId;
+    }
+
+    public String getStudyId()
+    {
+        return _studyId;
+    }
+}

--- a/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/SharedStudyIdTest.java
@@ -27,7 +27,6 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Git;
 import org.labkey.test.commands.mobileappstudy.EnrollParticipantCommand;
 import org.labkey.test.commands.mobileappstudy.EnrollmentTokenValidationCommand;
-import org.labkey.test.commands.mobileappstudy.ResolveEnrollmentTokenCommand;
 import org.labkey.test.components.mobileappstudy.TokenBatchPopup;
 import org.labkey.test.pages.mobileappstudy.SetupPage;
 import org.labkey.test.pages.mobileappstudy.TokenListPage;
@@ -252,50 +251,5 @@ public class SharedStudyIdTest extends BaseMobileAppStudyTest
         enrollCmd.setAllowDataSharing(allowDataSharing);
         enrollCmd.execute(400);
         assertEquals(expectedMessage, enrollCmd.getExceptionMessage());
-    }
-
-    @Test
-    // test the ability to resolve enrollment tokens
-    public void testResolveEnrollmentToken() throws IOException, CommandException
-    {
-        // test null, blank, invalid, and non-existent token - all should fail
-        ResolveEnrollmentTokenCommand resolveCmd = new ResolveEnrollmentTokenCommand("home", null, this::log);
-        testInvalid(resolveCmd, null, EnrollmentTokenValidationCommand.TOKEN_REQUIRED);
-        testInvalid(resolveCmd, "   ", EnrollmentTokenValidationCommand.TOKEN_REQUIRED);
-        String badToken = "ABCDEFGH"; // Wrong format - too short
-        testInvalid(resolveCmd, badToken, String.format(EnrollmentTokenValidationCommand.INVALID_TOKEN_FORMAT, badToken));
-        badToken = "ABCDEFGHI"; // Wrong format - bad checksum
-        testInvalid(resolveCmd, badToken, String.format(EnrollmentTokenValidationCommand.INVALID_TOKEN_FORMAT, badToken));
-        badToken = "RMNBREQMJ"; // Valid token, but doesn't exist
-        testInvalid(resolveCmd, badToken, String.format(EnrollmentTokenValidationCommand.INVALID_TOKEN_FORMAT, badToken));
-
-        TokenListPage tokenListPage = TokenListPage.beginAt(this, CLIENT_1_TOKEN_STUDY);
-        String goodToken1 = tokenListPage.getToken(4);
-
-        // Resolve multiple times
-        resolveCmd.setBatchToken(goodToken1);
-        resolveCmd.execute(200);
-        assertEquals(STUDY_ID, resolveCmd.getStudyId());
-        resolveCmd.execute(200);
-        assertEquals(STUDY_ID, resolveCmd.getStudyId());
-
-        // Resolve after enrollment
-        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, goodToken1, null, this::log);
-        enrollCmd.execute(200);
-        resolveCmd.execute(200);
-        assertEquals(STUDY_ID, resolveCmd.getStudyId());
-
-// TODO: Test a different study
-//        tokenListPage = TokenListPage.beginAt(this, CLIENT_2_TOKEN_STUDY);
-//        String goodToken2 = tokenListPage.getToken(1);
-//        resolveCmd = new ResolveEnrollmentTokenCommand("home", null, this::log);
-
-    }
-
-    private void testInvalid(ResolveEnrollmentTokenCommand resolveCmd, String token, String expectedErrorMessage)
-    {
-        resolveCmd.setBatchToken(token);
-        resolveCmd.execute(400);
-        assertEquals(expectedErrorMessage, resolveCmd.getExceptionMessage());
     }
 }

--- a/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
@@ -95,7 +95,7 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01 + "_INVALIDSTUDYNAME", token, this::log);
         cmd.execute(400);
         assertFalse("Enrollment token validation succeeded with an invalid studyId", cmd.getSuccess());
-        assertEquals("Unexpected error message", String.format(EnrollmentTokenValidationCommand.INVLAID_STUDYID_FORMAT, STUDY_NAME01 + "_INVALIDSTUDYNAME"), cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", String.format(EnrollmentTokenValidationCommand.INVALID_STUDYID_FORMAT, STUDY_NAME01 + "_INVALIDSTUDYNAME"), cmd.getExceptionMessage());
     }
 
     @Test

--- a/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
@@ -19,17 +19,20 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.categories.Git;
+import org.labkey.test.commands.mobileappstudy.EnrollParticipantCommand;
 import org.labkey.test.commands.mobileappstudy.EnrollmentTokenValidationCommand;
+import org.labkey.test.commands.mobileappstudy.ResolveEnrollmentTokenCommand;
 import org.labkey.test.components.mobileappstudy.TokenBatchPopup;
 import org.labkey.test.pages.mobileappstudy.SetupPage;
 import org.labkey.test.pages.mobileappstudy.TokenListPage;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test case to exercise the MobileAppStudy ValidateEnrollmentTokenAction
+ * Test case to exercise the MobileAppStudy ValidateEnrollmentTokenAction and ResolveEnrollmentTokenAction
  */
 @Category({Git.class})
 public class TokenValidationTest extends BaseMobileAppStudyTest
@@ -40,6 +43,8 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
     static final String PROJECT_NAME02 = "TokenValidationTest Project 2";
     static final String STUDY_NAME02 = "BLANKTOKENVALIDATION";
 
+    static final String PROJECT_NAME03 = "TokenValidationTest Project 3";
+    static final String STUDY_NAME03 = "RESOLVEVALIDATION";
 
     @Override
     void setupProjects()
@@ -48,6 +53,8 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         _containerHelper.createProject(PROJECT_NAME01, "Mobile App Study");
         _containerHelper.deleteProject(PROJECT_NAME02, false);
         _containerHelper.createProject(PROJECT_NAME02, "Mobile App Study");
+        _containerHelper.deleteProject(PROJECT_NAME03, false);
+        _containerHelper.createProject(PROJECT_NAME03, "Mobile App Study");
 
         goToProjectHome(PROJECT_NAME01);
         SetupPage setupPage = new SetupPage(this);
@@ -64,6 +71,17 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         setupPage.getStudySetupWebPart().setShortName(STUDY_NAME02);
         setupPage.validateSubmitButtonEnabled();
         setupPage.getStudySetupWebPart().clickSubmit();
+
+        // Third project to test resolving enrollment tokens in another study
+        goToProjectHome(PROJECT_NAME03);
+        setupPage = new SetupPage(this);
+        setupPage.getStudySetupWebPart().setShortName(STUDY_NAME03);
+        setupPage.validateSubmitButtonEnabled();
+        setupPage.getStudySetupWebPart().clickSubmit();
+
+        log("Create tokens.");
+        tokenBatchPopup = setupPage.getTokenBatchesWebPart().openNewBatchPopup();
+        tokenBatchPopup.createNewBatch("100");
     }
 
     @Nullable
@@ -142,5 +160,66 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME02, STUDY_NAME02, null, this::log);
         cmd.execute(200);
         assertTrue("Blank Enrollment token validation failed when it shouldn't have", cmd.getSuccess());
+    }
+
+    @Test
+    // test the ability to resolve enrollment tokens
+    public void testResolveEnrollmentToken()
+    {
+        // Always resolve from the /Home project... folder shouldn't matter
+        ResolveEnrollmentTokenCommand resolveCmd = new ResolveEnrollmentTokenCommand("home", null, this::log);
+
+        log("Attempt resolving without specifying enrollment token");
+        testInvalid(resolveCmd, null, EnrollmentTokenValidationCommand.TOKEN_REQUIRED);
+        testInvalid(resolveCmd, "   ", EnrollmentTokenValidationCommand.TOKEN_REQUIRED);
+
+        log("Attempt resolving a couple invalid tokens");
+        String badToken = "ABCDEFGH"; // Wrong format - too short
+        testInvalid(resolveCmd, badToken, String.format(EnrollmentTokenValidationCommand.INVALID_TOKEN_FORMAT, badToken));
+        badToken = "ABCDEFGHZ"; // Wrong format - bad checksum
+        testInvalid(resolveCmd, badToken, String.format(EnrollmentTokenValidationCommand.INVALID_TOKEN_FORMAT, badToken));
+
+        log("Attempt resolving a non-existent token");
+        badToken = "ABCDEFGHI"; // Valid token, but doesn't exist
+        resolveCmd.setBatchToken(badToken);
+        resolveCmd.execute(200);
+        assertFalse(resolveCmd.getSuccess());
+        assertNull(resolveCmd.getStudyId());
+        assertEquals("Token is not associated with a study ID", resolveCmd.getMessage());
+
+        TokenListPage tokenListPage = TokenListPage.beginAt(this, PROJECT_NAME01);
+        String goodToken1 = tokenListPage.getToken(1);
+
+        log("Resolve an existing token twice");
+        // Resolve multiple times
+        resolveCmd.setBatchToken(goodToken1);
+        resolveCmd.execute(200);
+        assertTrue(resolveCmd.getSuccess());
+        assertEquals(STUDY_NAME01, resolveCmd.getStudyId());
+        resolveCmd.execute(200);
+        assertTrue(resolveCmd.getSuccess());
+        assertEquals(STUDY_NAME01, resolveCmd.getStudyId());
+
+        log("Enroll and resolve again");
+        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand(PROJECT_NAME01, STUDY_NAME01, goodToken1, "true", this::log);
+        enrollCmd.execute(200);
+        resolveCmd.execute(200);
+        assertTrue(resolveCmd.getSuccess());
+        assertEquals(STUDY_NAME01, resolveCmd.getStudyId());
+
+        log("Resolve token from a second study");
+        tokenListPage = TokenListPage.beginAt(this, PROJECT_NAME03);
+        String goodToken2 = tokenListPage.getToken(0);
+        resolveCmd.setBatchToken(goodToken2);
+        resolveCmd.execute(200);
+        assertTrue(resolveCmd.getSuccess());
+        assertEquals(STUDY_NAME03, resolveCmd.getStudyId());
+    }
+
+    private void testInvalid(ResolveEnrollmentTokenCommand resolveCmd, String token, String expectedErrorMessage)
+    {
+        resolveCmd.setBatchToken(token);
+        resolveCmd.execute(400);
+        assertEquals(expectedErrorMessage, resolveCmd.getExceptionMessage());
     }
 }

--- a/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
@@ -182,7 +182,7 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         log("Attempt resolving a non-existent token");
         badToken = "ABCDEFGHI"; // Valid token, but doesn't exist
         resolveCmd.setBatchToken(badToken);
-        resolveCmd.execute(200);
+        resolveCmd.execute(404);
         assertFalse(resolveCmd.getSuccess());
         assertNull(resolveCmd.getStudyId());
         assertEquals("Token is not associated with a study ID", resolveCmd.getMessage());


### PR DESCRIPTION
#### Rationale
BTC is implementing a "search by enrollment token" feature in the MyStudies mobile app. This requires a new Response server API that resolves an enrollment token to the study ID associated with the study folder where the token was generated. More details are in this spec: https://docs.google.com/document/d/1H2VK2Vkh60SRt_s8sz8bZxIWfuTQaG2-ztzj7EPTHM4/edit

#### Changes
* Add ResolveEnrollmentToken API
* Add automated test for new API
