### PR TITLE
Switch to DisplayColumn.getFormattedHtml() and use HtmlString

### DIFF
--- a/src/org/labkey/mobileappstudy/query/EnrollmentTokenTable.java
+++ b/src/org/labkey/mobileappstudy/query/EnrollmentTokenTable.java
@@ -40,7 +40,9 @@ class EnrollmentTokenTable extends SimpleUserSchema.SimpleTable<MobileAppStudyQu
         @Override
         public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
         {
-            out.write("<span style='font-family: monospace'>" + getFormattedValue(ctx) + "</span>");
+            out.write("<span style='font-family: monospace'>");
+            getFormattedHtml(ctx).appendTo(out);
+            out.write("</span>");
         }
     };
 


### PR DESCRIPTION
#### Rationale
Switch to using HtmlString when rendering a grid or details value to ensure proper encoding. Fix up many problematic subclasses.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1602

#### Changes
* Remove deprecated getFormattedValue(), consolidate on getFormattedHtml()
* Use HtmlString to signal this is specifically for HTML