### PR TITLE
Update permissions

### DIFF
--- a/resources/web/mobileAppStudy/panel/enrollmentTokenBatchFormPanel.js
+++ b/resources/web/mobileAppStudy/panel/enrollmentTokenBatchFormPanel.js
@@ -58,17 +58,15 @@ Ext4.define('LABKEY.MobileAppStudy.EnrollmentTokenBatchFormPanel', {
 
         this.add(this.createForm());
         this.on (
-                {
-                    afterRender: function () {
-                        this.getSubmitButton().setDisabled(true);
-                    },
-                    close : function() {
-                        this.toggleGridButton();
-                    }
+            {
+                afterRender: function () {
+                    this.getSubmitButton().setDisabled(true);
+                },
+                close : function() {
+                    this.toggleGridButton();
                 }
+            }
         )
-
-
     },
 
     toggleGridButton: function() {
@@ -178,7 +176,6 @@ Ext4.define('LABKEY.MobileAppStudy.EnrollmentTokenBatchFormPanel', {
         btn.up('window').getCancelButton().setDisabled(true);
         btn.up('window').getEl().mask("Generating tokens ...");
 
-
         function onSuccess(response, options){
             btn.up('window').close();
             var batchId = JSON.parse(response.responseText).data.batchId;
@@ -189,12 +186,12 @@ Ext4.define('LABKEY.MobileAppStudy.EnrollmentTokenBatchFormPanel', {
         }
 
         function onError(response, options){
-            btn.setDisabled(false);
+            btn.up('window').close();
 
             var obj = Ext4.decode(response.responseText);
-            if (obj.errors && obj.errors[0].field == "form")
+            if (obj.exception)
             {
-                Ext4.Msg.alert("Error", "There were problems generating the tokens. " + obj.errors[0].message);
+                Ext4.Msg.alert("Error", "There were problems generating the tokens. " + obj.exception);
             }
         }
 
@@ -206,7 +203,6 @@ Ext4.define('LABKEY.MobileAppStudy.EnrollmentTokenBatchFormPanel', {
             failure: onError,
             scope: this
         });
-
     },
 
     getFieldValues: function()

--- a/src/org/labkey/mobileappstudy/MobileAppStudyController.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudyController.java
@@ -55,6 +55,7 @@ import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.RequiresSiteAdmin;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.FolderManagement.FolderManagementViewPostAction;
@@ -139,7 +140,7 @@ public class MobileAppStudyController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminPermission.class)
+    @RequiresPermission(ReadPermission.class)
     public class TokenBatchAction extends SimpleViewAction
     {
         @Override
@@ -155,7 +156,7 @@ public class MobileAppStudyController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminPermission.class)
+    @RequiresPermission(ReadPermission.class)
     public class TokenListAction extends SimpleViewAction
     {
         @Override

--- a/src/org/labkey/mobileappstudy/query/EnrollmentTokenBatchTable.java
+++ b/src/org/labkey/mobileappstudy/query/EnrollmentTokenBatchTable.java
@@ -35,6 +35,7 @@ class EnrollmentTokenBatchTable extends SimpleUserSchema.SimpleTable<MobileAppSt
     EnrollmentTokenBatchTable(MobileAppStudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, schema.getDbSchema().getTable(MobileAppStudySchema.ENROLLMENT_TOKEN_BATCH_TABLE), cf);
+        setReadOnly(true);
 
         // wrap all the existing columns
         wrapAllColumns();

--- a/src/org/labkey/mobileappstudy/query/EnrollmentTokenTable.java
+++ b/src/org/labkey/mobileappstudy/query/EnrollmentTokenTable.java
@@ -47,6 +47,7 @@ class EnrollmentTokenTable extends SimpleUserSchema.SimpleTable<MobileAppStudyQu
     EnrollmentTokenTable(MobileAppStudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, schema.getDbSchema().getTable(MobileAppStudySchema.ENROLLMENT_TOKEN_TABLE), cf);
+        setReadOnly(true);
 
         // wrap all the existing columns
         wrapAllColumns();

--- a/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
+++ b/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
@@ -21,6 +21,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.view.DataView;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.ClientDependency;
@@ -56,8 +57,13 @@ public class EnrollmentTokenBatchesWebPart extends QueryView
     protected void populateButtonBar(DataView view, ButtonBar bar)
     {
         super.populateButtonBar(view, bar);
-        ActionButton generateBtn = new ActionButton("New Batch");
-        generateBtn.setScript("Ext4.create('LABKEY.MobileAppStudy.EnrollmentTokenBatchFormPanel', {gridButton: this}).show();");
-        bar.add(generateBtn);
+
+        // Enable the "New Batch" button only for administrators, #41565
+        if (getContainer().hasPermission(getUser(), AdminPermission.class))
+        {
+            ActionButton generateBtn = new ActionButton("New Batch");
+            generateBtn.setScript("Ext4.create('LABKEY.MobileAppStudy.EnrollmentTokenBatchFormPanel', {gridButton: this}).show();");
+            bar.add(generateBtn);
+        }
     }
 }

--- a/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
+++ b/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
@@ -53,12 +53,15 @@ public class EnrollmentTokenBatchesWebPart extends QueryView
     {
         super.populateButtonBar(view, bar);
 
+        ActionButton generateBtn = new ActionButton("New Batch");
+        generateBtn.setTooltip("Create a batch of enrollment tokens");
+
         // Enable the "New Batch" button only for administrators, #41565
         if (getContainer().hasPermission(getUser(), AdminPermission.class))
-        {
-            ActionButton generateBtn = new ActionButton("New Batch");
             generateBtn.setScript("Ext4.create('LABKEY.MobileAppStudy.EnrollmentTokenBatchFormPanel', {gridButton: this}).show();");
-            bar.add(generateBtn);
-        }
+        else
+            generateBtn.setEnabled(false);
+
+        bar.add(generateBtn);
     }
 }

--- a/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
+++ b/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
@@ -40,11 +40,6 @@ public class EnrollmentTokenBatchesWebPart extends QueryView
         setSettings(createQuerySettings(viewContext));
         addClientDependency(ClientDependency.fromPath("Ext4"));
         addClientDependency(ClientDependency.fromPath("mobileAppStudy/panel/enrollmentTokenBatchFormPanel.js"));
-        setShowInsertNewButton(false);
-        setShowImportDataButton(false);
-        setShowDeleteButton(false);
-        setShowReports(false);
-        setShowUpdateColumn(false);
     }
 
     private QuerySettings createQuerySettings(ViewContext viewContext)

--- a/src/org/labkey/mobileappstudy/view/EnrollmentTokensWebPart.java
+++ b/src/org/labkey/mobileappstudy/view/EnrollmentTokensWebPart.java
@@ -31,12 +31,6 @@ public class EnrollmentTokensWebPart extends QueryView
     {
         super(QueryService.get().getUserSchema(viewContext.getUser(), viewContext.getContainer(), MobileAppStudySchema.NAME));
         setSettings(createQuerySettings(viewContext));
-        setShowInsertNewButton(false);
-        setShowImportDataButton(false);
-        setShowDeleteButton(false);
-        setShowReports(false);
-        setShowUpdateColumn(false);
-        setShowDetailsColumn(false);
     }
 
     private QuerySettings createQuerySettings(ViewContext viewContext)


### PR DESCRIPTION
#### Rationale
[Issue 41565: Deactivate button for generating tokens for those who lack permission to generate them](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41565)
[Issue 41602: EnrollmentToken and EnrollmentTokenBatch tables should be read-only](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=41602)

#### Changes
1. Correct "generate tokens" failure handling to display the exception message and close the popup on failures
2. Correct permissions on the "New Batch" button
3. Set EnrollmentToken and EnrollmentTokenBatch tables to read-only
4. Stop explicitly hiding the insert, import, delete, update UI elements on the enrollment token webparts; these are hidden automatically because the tables are now read-only
5. Add Chart/Report button back to the webparts for consistency with query schema grids
6. Switch enrollment token actions to read permissions for consistency with query schema grids
