### PR TITLE
Clean up participants properties metadata table as part of container cleanup

### DIFF
--- a/src/org/labkey/mobileappstudy/MobileAppStudyManager.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudyManager.java
@@ -376,6 +376,7 @@ public class MobileAppStudyManager
             ContainerUtil.purgeTable(schema.getTableInfoEnrollmentTokenBatch(), c, null);
             ContainerUtil.purgeTable(schema.getTableInfoStudy(), c, null);
             ContainerUtil.purgeTable(schema.getTableInfoResponseMetadata(), c, null);
+            ContainerUtil.purgeTable(schema.getTableInfoParticipantPropertyMetadata(), c, null);
 
             transaction.commit();
         }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40960
Entries into the ParticipantPropertiesMetadata table are not deleted when the associated container is deleted.

#### Changes
* added the participantPropertiesMetadata table to the container cleanup method
