### PR TITLE
Introduce MyStudies Coordinator role

### DIFF
--- a/src/org/labkey/mobileappstudy/MobileAppStudyController.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudyController.java
@@ -72,6 +72,7 @@ import org.labkey.mobileappstudy.data.SurveyResponse;
 import org.labkey.mobileappstudy.forwarder.ForwardingType;
 import org.labkey.mobileappstudy.participantproperties.ParticipantProperty;
 import org.labkey.mobileappstudy.query.ReadResponsesQuerySchema;
+import org.labkey.mobileappstudy.security.GenerateEnrollmentTokensPermission;
 import org.labkey.mobileappstudy.surveydesign.FileSurveyDesignProvider;
 import org.labkey.mobileappstudy.surveydesign.InvalidDesignException;
 import org.labkey.mobileappstudy.view.EnrollmentTokenBatchesWebPart;
@@ -175,7 +176,7 @@ public class MobileAppStudyController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminPermission.class)
+    @RequiresPermission(GenerateEnrollmentTokensPermission.class)
     public class GenerateTokensAction extends MutatingApiAction<GenerateTokensForm>
     {
         @Override

--- a/src/org/labkey/mobileappstudy/MobileAppStudyModule.java
+++ b/src/org/labkey/mobileappstudy/MobileAppStudyModule.java
@@ -23,11 +23,13 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleProperty;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.view.FolderManagement;
 import org.labkey.api.view.SimpleWebPartFactory;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.mobileappstudy.query.MobileAppStudyQuerySchema;
 import org.labkey.mobileappstudy.query.ReadResponsesQuerySchema;
+import org.labkey.mobileappstudy.security.MyStudiesCoordinator;
 import org.labkey.mobileappstudy.view.EnrollmentTokenBatchesWebPart;
 import org.labkey.mobileappstudy.view.StudyConfigWebPart;
 
@@ -113,6 +115,8 @@ public class MobileAppStudyModule extends DefaultModule
 
         //Startup shredding and forwarder jobs
         MobileAppStudyManager.get().doStartup();
+
+        RoleManager.registerRole(new MyStudiesCoordinator());
     }
 
     @Override

--- a/src/org/labkey/mobileappstudy/security/GenerateEnrollmentTokensPermission.java
+++ b/src/org/labkey/mobileappstudy/security/GenerateEnrollmentTokensPermission.java
@@ -1,0 +1,11 @@
+package org.labkey.mobileappstudy.security;
+
+import org.labkey.api.security.permissions.AbstractPermission;
+
+public class GenerateEnrollmentTokensPermission extends AbstractPermission
+{
+    public GenerateEnrollmentTokensPermission()
+    {
+        super("Generate Enrollment Tokens Permission", "Allows generation of enrollment tokens");
+    }
+}

--- a/src/org/labkey/mobileappstudy/security/MyStudiesCoordinator.java
+++ b/src/org/labkey/mobileappstudy/security/MyStudiesCoordinator.java
@@ -7,7 +7,7 @@ public class MyStudiesCoordinator extends AbstractModuleScopedRole
 {
     public MyStudiesCoordinator()
     {
-        super("MyStudies Coordinator", "MyStudies Coordinators may generate enrollment tokens.", MobileAppStudyModule.class, GenerateEnrollmentTokensPermission.class);
+        super("MyStudies Coordinator", "May generate batches of enrollment tokens.", MobileAppStudyModule.class, GenerateEnrollmentTokensPermission.class);
         excludeGuests();
     }
 }

--- a/src/org/labkey/mobileappstudy/security/MyStudiesCoordinator.java
+++ b/src/org/labkey/mobileappstudy/security/MyStudiesCoordinator.java
@@ -1,0 +1,13 @@
+package org.labkey.mobileappstudy.security;
+
+import org.labkey.api.security.roles.AbstractModuleScopedRole;
+import org.labkey.mobileappstudy.MobileAppStudyModule;
+
+public class MyStudiesCoordinator extends AbstractModuleScopedRole
+{
+    public MyStudiesCoordinator()
+    {
+        super("MyStudies Coordinator", "MyStudies Coordinators may generate enrollment tokens.", MobileAppStudyModule.class, GenerateEnrollmentTokensPermission.class);
+        excludeGuests();
+    }
+}

--- a/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
+++ b/src/org/labkey/mobileappstudy/view/EnrollmentTokenBatchesWebPart.java
@@ -21,11 +21,11 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.view.DataView;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.mobileappstudy.MobileAppStudySchema;
+import org.labkey.mobileappstudy.security.GenerateEnrollmentTokensPermission;
 
 /**
  * Web part for displaying current enrollment token batches and allowing
@@ -56,8 +56,8 @@ public class EnrollmentTokenBatchesWebPart extends QueryView
         ActionButton generateBtn = new ActionButton("New Batch");
         generateBtn.setTooltip("Create a batch of enrollment tokens");
 
-        // Enable the "New Batch" button only for administrators, #41565
-        if (getContainer().hasPermission(getUser(), AdminPermission.class))
+        // Enable the "New Batch" button for Administrators and MyStudies Coordinators, Issue 41770
+        if (getContainer().hasPermission(getUser(), GenerateEnrollmentTokensPermission.class))
             generateBtn.setScript("Ext4.create('LABKEY.MobileAppStudy.EnrollmentTokenBatchFormPanel', {gridButton: this}).show();");
         else
             generateBtn.setEnabled(false);

--- a/test/src/org/labkey/test/components/mobileappstudy/StudySetupWebPart.java
+++ b/test/src/org/labkey/test/components/mobileappstudy/StudySetupWebPart.java
@@ -90,6 +90,11 @@ public class StudySetupWebPart extends BodyWebPart<StudySetupWebPart.ElementCach
         return !classValue.toLowerCase().contains("x4-btn-disabled");
     }
 
+    public boolean isSubmitVisible()
+    {
+        return elementCache().submitButton.isDisplayed();
+    }
+
     public void clickSubmit()
     {
         submit();

--- a/test/src/org/labkey/test/components/mobileappstudy/TokenBatchesWebPart.java
+++ b/test/src/org/labkey/test/components/mobileappstudy/TokenBatchesWebPart.java
@@ -50,9 +50,6 @@ public class TokenBatchesWebPart extends BodyWebPart<TokenBatchesWebPart.Element
     public boolean isNewBatchEnabled()
     {
         return !elementCache().newBatchButton.getAttribute("class").contains("labkey-disabled-button");
-
-        // NOTE: This does not work... wonder why
-        // return elementCache().newBatchButton.isEnabled();
     }
 
     public TokenBatchPopup openNewBatchPopup()

--- a/test/src/org/labkey/test/components/mobileappstudy/TokenBatchesWebPart.java
+++ b/test/src/org/labkey/test/components/mobileappstudy/TokenBatchesWebPart.java
@@ -49,7 +49,10 @@ public class TokenBatchesWebPart extends BodyWebPart<TokenBatchesWebPart.Element
 
     public boolean isNewBatchEnabled()
     {
-        return elementCache().newBatchButton.isEnabled();
+        return !elementCache().newBatchButton.getAttribute("class").contains("labkey-disabled-button");
+
+        // NOTE: This does not work... wonder why
+        // return elementCache().newBatchButton.isEnabled();
     }
 
     public TokenBatchPopup openNewBatchPopup()

--- a/test/src/org/labkey/test/pages/mobileappstudy/SetupPage.java
+++ b/test/src/org/labkey/test/pages/mobileappstudy/SetupPage.java
@@ -44,6 +44,11 @@ public class SetupPage extends LabKeyPage<SetupPage.ElementCache> implements Web
         clearCache();
     }
 
+    public boolean isSubmitButtonVisible()
+    {
+        return elementCache().studySetupWebPart.isSubmitVisible();
+    }
+
     public void validateSubmitButtonDisabled()
     {
         log("Validate that the submit button is disabled.");

--- a/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
@@ -23,6 +23,7 @@ import org.labkey.test.commands.mobileappstudy.EnrollParticipantCommand;
 import org.labkey.test.commands.mobileappstudy.EnrollmentTokenValidationCommand;
 import org.labkey.test.commands.mobileappstudy.ResolveEnrollmentTokenCommand;
 import org.labkey.test.components.mobileappstudy.TokenBatchPopup;
+import org.labkey.test.components.mobileappstudy.TokenBatchesWebPart;
 import org.labkey.test.pages.mobileappstudy.SetupPage;
 import org.labkey.test.pages.mobileappstudy.TokenListPage;
 
@@ -214,6 +215,35 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         resolveCmd.execute(200);
         assertTrue(resolveCmd.getSuccess());
         assertEquals(STUDY_NAME03, resolveCmd.getStudyId());
+    }
+
+    @Test
+    public void testMyStudiesCoordinatorRole()
+    {
+        goToProjectHome(PROJECT_NAME01);
+        SetupPage setupPage = new SetupPage(this);
+        TokenBatchesWebPart batchesWebPart = setupPage.getTokenBatchesWebPart();
+
+        // Test for Administrator
+        assertTrue(batchesWebPart.isNewBatchPresent());
+        assertTrue(batchesWebPart.isNewBatchEnabled());
+        setupPage.validateSubmitButtonEnabled();
+
+        // Test for Reader
+        impersonateRole("Reader");
+        assertTrue(batchesWebPart.isNewBatchPresent());
+        assertFalse(batchesWebPart.isNewBatchEnabled());
+        setupPage.validateSubmitButtonDisabled();
+        stopImpersonating();
+
+        // Test for MyStudies Coordinator
+        impersonateRoles("Reader","MyStudies Coordinator");
+        assertTrue(batchesWebPart.isNewBatchPresent());
+        assertTrue(batchesWebPart.isNewBatchEnabled());   // Should be able to create a new batch
+        TokenBatchPopup tokenBatchPopup = batchesWebPart.openNewBatchPopup();
+        tokenBatchPopup.createNewBatch("100");
+        setupPage.validateSubmitButtonDisabled();  // Shouldn't have admin capabilities like changing study setup
+        stopImpersonating();
     }
 
     private void testInvalid(ResolveEnrollmentTokenCommand resolveCmd, String token, String expectedErrorMessage)

--- a/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
@@ -242,7 +242,8 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         assertTrue(batchesWebPart.isNewBatchEnabled());  // Should be able to create a new batch
         assertFalse(setupPage.isSubmitButtonVisible());  // Submit button should NOT be present
         TokenBatchPopup tokenBatchPopup = batchesWebPart.openNewBatchPopup();
-        tokenBatchPopup.createNewBatch("100");
+        TokenListPage tokenListPage = tokenBatchPopup.createNewBatch("100");
+        assertEquals("Wrong number of tokens generated for MyStudies Coordinator", 100, tokenListPage.getNumTokens());
         stopImpersonating();
     }
 

--- a/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
@@ -237,7 +237,7 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         stopImpersonating(false);
 
         // Test for MyStudies Coordinator
-        impersonateRoles("Reader","MyStudies Coordinator");
+        impersonateRoles("Reader", "MyStudies Coordinator");
         assertTrue(batchesWebPart.isNewBatchPresent());
         assertTrue(batchesWebPart.isNewBatchEnabled());  // Should be able to create a new batch
         assertFalse(setupPage.isSubmitButtonVisible());  // Submit button should NOT be present

--- a/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/mobileappstudy/TokenValidationTest.java
@@ -227,22 +227,22 @@ public class TokenValidationTest extends BaseMobileAppStudyTest
         // Test for Administrator
         assertTrue(batchesWebPart.isNewBatchPresent());
         assertTrue(batchesWebPart.isNewBatchEnabled());
-        setupPage.validateSubmitButtonEnabled();
+        setupPage.validateSubmitButtonDisabled();  // Submit button should be present
 
         // Test for Reader
         impersonateRole("Reader");
         assertTrue(batchesWebPart.isNewBatchPresent());
         assertFalse(batchesWebPart.isNewBatchEnabled());
-        setupPage.validateSubmitButtonDisabled();
-        stopImpersonating();
+        assertFalse(setupPage.isSubmitButtonVisible());  // Submit button should NOT be present
+        stopImpersonating(false);
 
         // Test for MyStudies Coordinator
         impersonateRoles("Reader","MyStudies Coordinator");
         assertTrue(batchesWebPart.isNewBatchPresent());
-        assertTrue(batchesWebPart.isNewBatchEnabled());   // Should be able to create a new batch
+        assertTrue(batchesWebPart.isNewBatchEnabled());  // Should be able to create a new batch
+        assertFalse(setupPage.isSubmitButtonVisible());  // Submit button should NOT be present
         TokenBatchPopup tokenBatchPopup = batchesWebPart.openNewBatchPopup();
         tokenBatchPopup.createNewBatch("100");
-        setupPage.validateSubmitButtonDisabled();  // Shouldn't have admin capabilities like changing study setup
         stopImpersonating();
     }
 


### PR DESCRIPTION
#### Rationale
At the moment, only administrators can generate enrollment tokens. As discussed in [#41596](https://www.labkey.org/FDA%20Mobile%20App/Support%20Tickets/issues-details.view?issueId=41596), Harvard-Pilgrim would like to grant their study coordinators the ability to generate batches of enrollment tokens without granting them any administrator permissions (delete folders, assign roles, change webparts, etc.). The "MyStudies Coordinator" role accommodates this need.
