### PR TITLE
Add isOpenSource property

### DIFF
--- a/distributions/fda/build.gradle
+++ b/distributions/fda/build.gradle
@@ -2,7 +2,9 @@ import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 
-apply plugin: 'org.labkey.distribution'
+plugins {
+    id 'org.labkey.build.distribution'
+}
 
 buildscript {
     repositories {

--- a/distributions/fda/gradle.properties
+++ b/distributions/fda/gradle.properties
@@ -1,0 +1,1 @@
+isOpenSource

--- a/distributions/fda/gradle.properties
+++ b/distributions/fda/gradle.properties
@@ -1,1 +1,1 @@
-isOpenSource
+isOpenSource=true


### PR DESCRIPTION
#### Rationale
We are enabling the ability to provide differently licensed versions of some of our third-party dependencies.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/tree/v1.24.0
* https://github.com/LabKey/distributions/pull/145

#### Changes
* Update plugin id syntax
* Add isOpenSource=true property